### PR TITLE
Day by day

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
 
   test:
     image: 'modispds:latest'
-    entrypoint: bash -c 'nosetests --with-coverage --cover-package modispds --cover-inclusive -v -s;'
+    entrypoint: bash -c 'nosetests --with-coverage --cover-package modispds --cover-inclusive --with-timer -v -s;'
     working_dir: /work
     volumes:
       - '.:/work'

--- a/modispds/cmr.py
+++ b/modispds/cmr.py
@@ -44,23 +44,27 @@ def query(start_date, end_date, product='MCD43A4.006', provider='LPDAAC_ECS'):
     each image.
     """
     prod, ver = product.split('.')
+
+    granules = []
+
+    date1 = parse(start_date)
+    date2 = parse(end_date)
+
     temporal = '{0}T00:00:00Z,{1}T23:59:00Z'.format(start_date, end_date)
-    start_date = parse(start_date)
-    end_date = parse(end_date)
 
     try:
         _granules = cmr.searchGranule(provider=provider, short_name=prod, version=ver,
-                                      temporal=temporal, sort_key='start_date', limit=10000)
+                                      temporal=temporal, sort_key='start_date', limit=100000)
     except HTTPError as error:
         raise ValueError('Error with CMR:', error.read())
 
     # filter dates
-    granules = []
     for gran in _granules:
         dt = gran['Granule']['Temporal']['RangeDateTime']['BeginningDateTime'].split('T')[0]
         date = parse(dt) + datetime.timedelta(days=products[prod]['day_offset'])
-        if (start_date <= date <= end_date):
+        if (date1 <= date <= date2):
             granules.append(gran)
+    log.debug("%s granules found within %s - %s" % (len(_granules), start_date, end_date))
     return granules
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 nose==1.3.7
 coverage==4.3.4
+nose-timer==0.6.0

--- a/test/test_cmr.py
+++ b/test/test_cmr.py
@@ -26,11 +26,6 @@ class TestCMR(unittest.TestCase):
         q = query(self.date1, self.date2)
         self.assertEqual(len(q), 598)
 
-    def _test_query_5days(self):
-        """ Query CMR for five days """
-        q = query(self.date1, '2016-01-05')
-        self.assertEqual(len(q), 1497)
-
     def _test_query_30days(self):
         """ Query CMR for 30 days """
         q = query('2016-01-01', '2016-01-30')

--- a/test/test_cmr.py
+++ b/test/test_cmr.py
@@ -7,6 +7,7 @@ class TestCMR(unittest.TestCase):
     """ Test query and downloading from CMR """
 
     date1 = '2016-01-01'
+    date2 = '2016-01-02'
     url = 'http://e4ftl01.cr.usgs.gov//MODV6_Cmp_B/MOTA/MCD43A4.006/2016.01.01/MCD43A4.A2016001.h11v12.006.2016174075640.hdf'
 
     @classmethod
@@ -19,6 +20,21 @@ class TestCMR(unittest.TestCase):
         self.assertEqual(len(self.q), 299)
         keys = self.q[0].keys()
         self.assertTrue('Granule' in keys)
+
+    def test_query_2days(self):
+        """ Query CMR for two days """
+        q = query(self.date1, self.date2)
+        self.assertEqual(len(q), 598)
+
+    def _test_query_5days(self):
+        """ Query CMR for five days """
+        q = query(self.date1, '2016-01-05')
+        self.assertEqual(len(q), 1497)
+
+    def _test_query_30days(self):
+        """ Query CMR for 30 days """
+        q = query('2016-01-01', '2016-01-30')
+        self.assertEqual(len(q), 9272)
 
     def test_download(self):
         """ Download a file from CMR """


### PR DESCRIPTION
minor updates, tests for date ranges greater than 1 day.

Limitations with CMR make it impractical (takes too long) for ranges much longer than a month, but currently the library will not prevent you from making such a request.